### PR TITLE
add quiet option and args environment for AWS Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ fetch-redhat:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -92,6 +93,8 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
 ```
@@ -115,6 +118,7 @@ fetch-debian:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -130,6 +134,8 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
 ```
@@ -153,6 +159,7 @@ fetch-ubuntu:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -168,6 +175,8 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
 ```
@@ -196,6 +205,7 @@ fetch-suse:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -211,6 +221,8 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -opensuse
@@ -244,6 +256,7 @@ fetch-oracle:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -259,6 +272,8 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
 ```
@@ -708,6 +723,7 @@ server:
                 [-dbtype=sqlite3|mysql|postgres|redis]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
   -bind string
@@ -720,6 +736,8 @@ server:
         debug mode (default: false)
   -debug-sql
         SQL debug mode (default: false)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -port string

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ type FetchDebianCmd struct {
 	// ovalFiles bool
 	Debug     bool
 	DebugSQL  bool
+	Quiet     bool
 	LogDir    string
 	DBPath    string
 	DBType    string
@@ -42,6 +44,7 @@ func (*FetchDebianCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -52,10 +55,9 @@ For the first time, run the blow command to fetch data for all versions.
 
 // SetFlags set flag
 func (p *FetchDebianCmd) SetFlags(f *flag.FlagSet) {
-	f.BoolVar(&p.Debug, "debug", false,
-		"debug mode")
-	f.BoolVar(&p.DebugSQL, "debug-sql", false,
-		"SQL debug mode")
+	f.BoolVar(&p.Debug, "debug", false, "debug mode")
+	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -77,7 +79,12 @@ func (p *FetchDebianCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *FetchDebianCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.LogDir)
+	c.Conf.Quiet = p.Quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.LogDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.LogDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.DebugSQL
 	c.Conf.Debug = p.Debug

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -21,6 +22,7 @@ import (
 type FetchRedHatCmd struct {
 	Debug     bool
 	DebugSQL  bool
+	Quiet     bool
 	LogDir    string
 	DBPath    string
 	DBType    string
@@ -42,6 +44,7 @@ func (*FetchRedHatCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -56,6 +59,7 @@ For the first time, run the blow command to fetch data for all versions.
 func (p *FetchRedHatCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.Debug, "debug", false, "debug mode")
 	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -77,7 +81,12 @@ func (p *FetchRedHatCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *FetchRedHatCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.LogDir)
+	c.Conf.Quiet = p.Quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.LogDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.LogDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.DebugSQL
 	c.Conf.Debug = p.Debug

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ type FetchSUSECmd struct {
 	SUSEOpenstackCloud    bool
 	Debug                 bool
 	DebugSQL              bool
+	Quiet                 bool
 	LogDir                string
 	DBPath                string
 	DBType                string
@@ -51,6 +53,7 @@ func (*FetchSUSECmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -70,6 +73,7 @@ func (p *FetchSUSECmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&p.Debug, "debug", false, "debug mode")
 	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -91,7 +95,12 @@ func (p *FetchSUSECmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *FetchSUSECmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.LogDir)
+	c.Conf.Quiet = p.Quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.LogDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.LogDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.DebugSQL
 	c.Conf.Debug = p.Debug

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ import (
 type FetchUbuntuCmd struct {
 	Debug     bool
 	DebugSQL  bool
+	Quiet     bool
 	LogDir    string
 	DBPath    string
 	DBType    string
@@ -41,6 +43,7 @@ func (*FetchUbuntuCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for all versions.
@@ -51,10 +54,9 @@ For the first time, run the blow command to fetch data for all versions.
 
 // SetFlags set flag
 func (p *FetchUbuntuCmd) SetFlags(f *flag.FlagSet) {
-	f.BoolVar(&p.Debug, "debug", false,
-		"debug mode")
-	f.BoolVar(&p.DebugSQL, "debug-sql", false,
-		"SQL debug mode")
+	f.BoolVar(&p.Debug, "debug", false, "debug mode")
+	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -76,7 +78,12 @@ func (p *FetchUbuntuCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *FetchUbuntuCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.LogDir)
+	c.Conf.Quiet = p.Quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.LogDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.LogDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.DebugSQL
 	c.Conf.Debug = p.Debug

--- a/commands/server.go
+++ b/commands/server.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 
 	"github.com/google/subcommands"
@@ -17,6 +18,7 @@ import (
 type ServerCmd struct {
 	debug    bool
 	debugSQL bool
+	quiet    bool
 	logDir   string
 
 	dbpath string
@@ -41,6 +43,7 @@ func (*ServerCmd) Usage() string {
 		[-dbtype=mysql|sqlite3]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 `
@@ -48,10 +51,9 @@ func (*ServerCmd) Usage() string {
 
 // SetFlags set flag
 func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
-	f.BoolVar(&p.debug, "debug", false,
-		"debug mode (default: false)")
-	f.BoolVar(&p.debugSQL, "debug-sql", false,
-		"SQL debug mode (default: false)")
+	f.BoolVar(&p.debug, "debug", false, "debug mode (default: false)")
+	f.BoolVar(&p.debugSQL, "debug-sql", false, "SQL debug mode (default: false)")
+	f.BoolVar(&p.quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -73,7 +75,12 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.logDir)
+	c.Conf.Quiet = p.quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.logDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.logDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.Debug = p.debug

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ var Conf Config
 type Config struct {
 	Debug     bool
 	DebugSQL  bool
+	Quiet     bool
 	DBPath    string
 	DBType    string
 	Bind      string `valid:"ipv4"`

--- a/db/redis.go
+++ b/db/redis.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cheggaaa/pb"
 	"github.com/go-redis/redis"
 	c "github.com/kotakanbe/goval-dictionary/config"
 	"github.com/kotakanbe/goval-dictionary/log"
@@ -168,13 +167,10 @@ func (d *RedisDriver) GetByCveID(osVer, cveID string) ([]models.Definition, erro
 
 // InsertOval inserts OVAL
 func (d *RedisDriver) InsertOval(root *models.Root, meta models.FetchMeta) (err error) {
-	bar := pb.StartNew(len(root.Definitions))
-
 	for chunked := range chunkSlice(root.Definitions, 10) {
 		var pipe redis.Pipeliner
 		pipe = d.conn.Pipeline()
 		for _, c := range chunked {
-			bar.Increment()
 			var dj []byte
 			if dj, err = json.Marshal(c); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
@@ -199,7 +195,6 @@ func (d *RedisDriver) InsertOval(root *models.Root, meta models.FetchMeta) (err 
 			return fmt.Errorf("Failed to exec pipeline. err: %s", err)
 		}
 	}
-	bar.Finish()
 	return nil
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,22 +1,41 @@
 package log
 
 import (
+	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/k0kubun/pp"
 	formatter "github.com/kotakanbe/logrus-prefixed-formatter"
+	colorable "github.com/mattn/go-colorable"
 	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
 )
 
-var logger *logrus.Entry
+var (
+	logger              *logrus.Entry
+	logrusDefaultOutput = os.Stderr
+	ppDefaultOutput     = colorable.NewColorableStderr()
+)
 
-// Initialize logger
-func Initialize(logDir string) {
+func init() {
 	log := logrus.New()
 	log.Formatter = &formatter.TextFormatter{}
-	log.Out = os.Stderr
+	log.Out = ioutil.Discard
 	log.Level = logrus.InfoLevel
+	fields := logrus.Fields{"prefix": ""}
+	logger = log.WithFields(fields)
+}
+
+// Initialize logger
+func Initialize(logDir string, output ...io.Writer) {
+	logger.Logger.Out = logrusDefaultOutput
+	pp.SetDefaultOutput(ppDefaultOutput)
+	if 0 < len(output) {
+		logger.Logger.Out = output[0]
+		pp.SetDefaultOutput(output[0])
+	}
 
 	// File output
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
@@ -27,7 +46,7 @@ func Initialize(logDir string) {
 
 	if _, err := os.Stat(logDir); err == nil {
 		path := filepath.Join(logDir, "goval.log")
-		log.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
+		logger.Logger.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
 			logrus.DebugLevel: path,
 			logrus.InfoLevel:  path,
 			logrus.WarnLevel:  path,
@@ -36,9 +55,6 @@ func Initialize(logDir string) {
 			logrus.PanicLevel: path,
 		}))
 	}
-
-	fields := logrus.Fields{"prefix": ""}
-	logger = log.WithFields(fields)
 }
 
 // SetDebug set debug level

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/google/subcommands"
 	"github.com/kotakanbe/goval-dictionary/commands"
@@ -34,7 +35,11 @@ func main() {
 
 	var v = flag.Bool("v", false, "Show version")
 
-	flag.Parse()
+	if envArgs := os.Getenv("GOVAL_DICTIONARY_ARGS"); 0 < len(envArgs) {
+		flag.CommandLine.Parse(strings.Fields(envArgs))
+	} else {
+		flag.Parse()
+	}
 
 	if *v {
 		fmt.Printf("goval-dictionary %s %s\n", version, revision)


### PR DESCRIPTION
1. add quiet option
2. change all output to stderr
3. add args environment
4. no output if not execute log.Initialize 
(when we used goval-dictionary's method without log.Initialize, panic occured.)