### PR TITLE
Fix a panic when specify no supported version

### DIFF
--- a/fetcher/alpine.go
+++ b/fetcher/alpine.go
@@ -24,6 +24,10 @@ func newAlpineFetchRequests(target []string) (reqs []fetchRequest) {
 // https://git.alpinelinux.org/cgit/alpine-secdb/tree/
 func FetchAlpineFiles(versions []string) ([]FetchResult, error) {
 	reqs := newAlpineFetchRequests(versions)
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
 	results, err := fetchFeedFileConcurrently(reqs)
 	if err != nil {
 		return nil,

--- a/fetcher/debian.go
+++ b/fetcher/debian.go
@@ -13,7 +13,7 @@ func newDebianFetchRequests(target []string) (reqs []fetchRequest) {
 	for _, v := range target {
 		var name string
 		if name = debianName(v); name == "unknown" {
-			log.Warnf("Skip unknown ubuntu version : %s.", v)
+			log.Warnf("Skip unknown debian version : %s.", v)
 			continue
 		}
 		reqs = append(reqs, fetchRequest{

--- a/fetcher/debian.go
+++ b/fetcher/debian.go
@@ -13,7 +13,7 @@ func newDebianFetchRequests(target []string) (reqs []fetchRequest) {
 	for _, v := range target {
 		var name string
 		if name = debianName(v); name == "unknown" {
-			log.Warnf("Skip unkown ubuntu version : %s.", v)
+			log.Warnf("Skip unknown ubuntu version : %s.", v)
 			continue
 		}
 		reqs = append(reqs, fetchRequest{

--- a/fetcher/debian.go
+++ b/fetcher/debian.go
@@ -42,6 +42,10 @@ func debianName(major string) string {
 // FetchDebianFiles fetch OVAL from RedHat
 func FetchDebianFiles(versions []string) ([]FetchResult, error) {
 	reqs := newDebianFetchRequests(versions)
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
 	results, err := fetchFeedFileConcurrently(reqs)
 	if err != nil {
 		return nil,

--- a/fetcher/oracle.go
+++ b/fetcher/oracle.go
@@ -16,6 +16,10 @@ func newOracleFetchRequests() (reqs []fetchRequest) {
 // FetchOracleFiles fetch OVAL from Oracle
 func FetchOracleFiles() ([]FetchResult, error) {
 	reqs := newOracleFetchRequests()
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
 	results, err := fetchFeedFileConcurrently(reqs)
 	if err != nil {
 		return nil,

--- a/fetcher/redhat.go
+++ b/fetcher/redhat.go
@@ -19,6 +19,10 @@ func newRedHatFetchRequests(target []string) (reqs []fetchRequest) {
 // FetchRedHatFiles fetch OVAL from RedHat
 func FetchRedHatFiles(versions []string) ([]FetchResult, error) {
 	reqs := newRedHatFetchRequests(versions)
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
 	results, err := fetchFeedFileConcurrently(reqs)
 	if err != nil {
 		return nil,

--- a/fetcher/suse.go
+++ b/fetcher/suse.go
@@ -23,6 +23,10 @@ func newSUSEFetchRequests(suseType string, target []string) (reqs []fetchRequest
 // FetchSUSEFiles fetch OVAL from RedHat
 func FetchSUSEFiles(suseType string, versions []string) ([]FetchResult, error) {
 	reqs := newSUSEFetchRequests(suseType, versions)
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
 	results, err := fetchFeedFileConcurrently(reqs)
 	if err != nil {
 		return nil,

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -12,7 +12,7 @@ func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
 	for _, v := range target {
 		var name string
 		if name = ubuntuName(v); name == "unknown" {
-			log.Warnf("Skip unkown ubuntu version : %s.", v)
+			log.Warnf("Skip unknown ubuntu version : %s.", v)
 			continue
 		}
 		reqs = append(reqs, fetchRequest{

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -39,6 +39,10 @@ func ubuntuName(major string) string {
 // FetchUbuntuFiles fetch OVAL from Ubuntu
 func FetchUbuntuFiles(versions []string) ([]FetchResult, error) {
 	reqs := newUbuntuFetchRequests(versions)
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
 	results, err := fetchFeedFileConcurrently(reqs)
 	if err != nil {
 		return nil,


### PR DESCRIPTION
Hello.

I had found a buggy behavior when specify no supported version of system distribution such like below command.
```sh
$ goval-dictionary fetch-ubuntu 17
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x8437e2]

goroutine 1 [running]:
github.com/kotakanbe/goval-dictionary/vendor/github.com/cheggaaa/pb.(*Pool).Stop(0x0, 0xc42024b100, 0x0)
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/vendor/github.com/cheggaaa/pb/pool.go:76 +0x22
github.com/kotakanbe/goval-dictionary/fetcher.fetchFeedFileConcurrently(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/fetcher/util.go:100 +0xb1d
github.com/kotakanbe/goval-dictionary/fetcher.FetchUbuntuFiles(0xc420268f40, 0x1, 0x1, 0x0, 0x1, 0xc420268f40, 0x0, 0x1)
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/fetcher/ubuntu.go:42 +0x65
github.com/kotakanbe/goval-dictionary/commands.(*FetchUbuntuCmd).Execute(0xc42026e910, 0xf2c920, 0xc420018068, 0xc420260840, 0x0, 0x0, 0x0, 0x0)
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/commands/fetch-ubuntu.go:119 +0x3bd
github.com/kotakanbe/goval-dictionary/vendor/github.com/google/subcommands.(*Commander).Execute(0xc42006e000, 0xf2c920, 0xc420018068, 0x0, 0x0, 0x0, 0x0)
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/vendor/github.com/google/subcommands/subcommands.go:141 +0x2a3
github.com/kotakanbe/goval-dictionary/vendor/github.com/google/subcommands.Execute(0xf2c920, 0xc420018068, 0x0, 0x0, 0x0, 0xc42024aff8)
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/vendor/github.com/google/subcommands/subcommands.go:371 +0x5f
main.main()
	/home/vuls/go/src/github.com/kotakanbe/goval-dictionary/main.go:51 +0x33b
```
I didn't understand why it panic by SIGSEGV, even though I found how to fix.

In addition, I also found incorrect error messages, so I fixed these.
