### PR TITLE
Change fetch process

### DIFF
--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -115,8 +115,8 @@ func (p *FetchRedHatCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 	v := map[string]bool{}
 	for _, arg := range f.Args() {
 		ver, err := strconv.Atoi(arg)
-		if err != nil || ver < 5 {
-			log.Errorf("Specify version to fetch (from 5 to latest RHEL version), arg: %s", arg)
+		if err != nil || ver < 3 {
+			log.Errorf("Specify version to fetch (from 3 to latest RHEL version), arg: %s", arg)
 			return subcommands.ExitUsageError
 		}
 		v[arg] = true

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,9 @@ const (
 	// Ubuntu16 is Ubuntu Xenial
 	Ubuntu16 = "xenial"
 
+	// Ubuntu18 is Ubuntu Bionic
+	Ubuntu18 = "bionic"
+
 	// Debian7 is wheezy
 	Debian7 = "wheezy"
 
@@ -38,6 +41,9 @@ const (
 
 	// Debian10 is buster
 	Debian10 = "buster"
+
+	// Debian11 is bullseye
+	Debian11 = "bullseye"
 
 	// OpenSUSE is
 	OpenSUSE = "opensuse"

--- a/fetcher/debian.go
+++ b/fetcher/debian.go
@@ -2,20 +2,16 @@ package fetcher
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kotakanbe/goval-dictionary/config"
-	"github.com/kotakanbe/goval-dictionary/log"
 )
 
 // https://www.debian.org/security/oval/
 func newDebianFetchRequests(target []string) (reqs []fetchRequest) {
 	const t = "https://www.debian.org/security/oval/oval-definitions-%s.xml"
 	for _, v := range target {
-		var name string
-		if name = debianName(v); name == "unknown" {
-			log.Warnf("Skip unknown debian version : %s.", v)
-			continue
-		}
+		name := debianName(v)
 		reqs = append(reqs, fetchRequest{
 			target: v,
 			url:    fmt.Sprintf(t, name),
@@ -34,8 +30,10 @@ func debianName(major string) string {
 		return config.Debian9
 	case "10":
 		return config.Debian10
+	case "11":
+		return config.Debian11
 	default:
-		return "unknown"
+		return strings.ToLower(major)
 	}
 }
 

--- a/fetcher/suse.go
+++ b/fetcher/suse.go
@@ -2,6 +2,7 @@ package fetcher
 
 import (
 	"fmt"
+	c "github.com/kotakanbe/goval-dictionary/config"
 )
 
 // http://ftp.suse.com/pub/projects/security/oval/opensuse.leap.42.2.xml
@@ -10,8 +11,12 @@ import (
 // http://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml
 // http://ftp.suse.com/pub/projects/security/oval/suse.openstack.cloud.7.xml
 func newSUSEFetchRequests(suseType string, target []string) (reqs []fetchRequest) {
-	const t = "http://ftp.suse.com/pub/projects/security/oval/%s.%s.xml"
 	for _, v := range target {
+		t := "https://support.novell.com/security/oval/%s.%s.xml"
+		if suseType == c.OpenSUSELeap && v == "42.3" {
+			// Measures against "Access Forbidden"
+			t = "http://ftp.suse.com/pub/projects/security/oval/%s.%s.xml"
+		}
 		reqs = append(reqs, fetchRequest{
 			target: v,
 			url:    fmt.Sprintf(t, suseType, v),

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -2,19 +2,15 @@ package fetcher
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kotakanbe/goval-dictionary/config"
-	"github.com/kotakanbe/goval-dictionary/log"
 )
 
 func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
 	const t = "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml"
 	for _, v := range target {
-		var name string
-		if name = ubuntuName(v); name == "unknown" {
-			log.Warnf("Skip unknown ubuntu version : %s.", v)
-			continue
-		}
+		name := ubuntuName(v)
 		reqs = append(reqs, fetchRequest{
 			target: v,
 			url:    fmt.Sprintf(t, name),
@@ -31,8 +27,10 @@ func ubuntuName(major string) string {
 		return config.Ubuntu14
 	case "16":
 		return config.Ubuntu16
+	case "18":
+		return config.Ubuntu18
 	default:
-		return "unknown"
+		return strings.ToLower(major)
 	}
 }
 


### PR DESCRIPTION
- Enable to obtain OVAL of RHEL 3 and 4. **It is useless for Vuls.**
- You can specify the codename with fetch-debian command and fetch-ubuntu command.
- Changed the OVAL source of SUSE.