### PR TITLE
fix: change gorm column size of Definition>Description

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -29,7 +29,7 @@ type Definition struct {
 
 	DefinitionID  string
 	Title         string
-	Description   string
+	Description   string `gorm:"size:4096"`
 	Advisory      Advisory
 	Debian        Debian
 	AffectedPacks []Package


### PR DESCRIPTION
An error occurred while inserting OVAL feed of RedHat 7 into MySQL.

```
}, err: Error 1406: Data too long for column 'description' at row 1
```
