### PR TITLE
fix(redhat): occasionally no cve tag in advisory tag of RedHat OVAL

### DIFF
--- a/models/redhat.go
+++ b/models/redhat.go
@@ -1,11 +1,14 @@
 package models
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/ymomoi/goval-parser/oval"
 )
+
+var cveIDPattern = regexp.MustCompile(`(CVE-\d{4}-\d{4,})`)
 
 // ConvertRedHatToModel Convert OVAL to models
 func ConvertRedHatToModel(root *oval.Root) (defs []Definition) {
@@ -46,6 +49,15 @@ func ConvertRedHatToModel(root *oval.Root) (defs []Definition) {
 				URL:        b.URL,
 				Title:      b.Title,
 			})
+		}
+
+		if len(cves) == 0 {
+			for _, b := range d.Advisory.Bugzillas {
+				fields := strings.Fields(b.Title)
+				if len(fields) > 0 && cveIDPattern.MatchString(fields[0]) {
+					cves = append(cves, Cve{CveID: fields[0]})
+				}
+			}
 		}
 
 		const timeformat = "2006-01-02"


### PR DESCRIPTION
In the following case, goval-dictionary fails to insert CVE information to `cves` table (no `cve` tag under `advisory` tag).

```
<advisory from="secalert@redhat.com">
     <severity>Important</severity>
     <rights>Copyright 2018 Red Hat, Inc.</rights>
     <issued date="2018-01-03"/>
     <updated date="2018-01-03"/>
     <bugzilla href="https://bugzilla.redhat.com/1519778" id="1519778">CVE-2017-5753 hw: cpu: speculative execution bounds-check bypass</bugzilla>
     <bugzilla href="https://bugzilla.redhat.com/1519780" id="1519780">CVE-2017-5715 hw: cpu: speculative execution branch target injection</bugzilla>
     <bugzilla href="https://bugzilla.redhat.com/1519781" id="1519781">CVE-2017-5754 hw: cpu: speculative execution permission faults handling</bugzilla>
     <affected_cpe_list>
      <cpe>cpe:/o:redhat:enterprise_linux:7</cpe>
     </affected_cpe_list>
</advisory>
```

Then, I extract CVE-ID from `bugzilla` tag if no `cve` tag.