### PR TITLE
fix(ubuntu): Support latest OVAL format for Ubuntu

### DIFF
--- a/models/ubuntu_test.go
+++ b/models/ubuntu_test.go
@@ -1,0 +1,92 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/k0kubun/pp"
+)
+
+func TestParseNotFixedYet(t *testing.T) {
+	var tests = []struct {
+		comment  string
+		expected Package
+	}{
+		{
+			comment: `xine-console package in bionic is affected and needs fixing.`,
+			expected: Package{
+				Name:        "xine-console",
+				NotFixedYet: true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		actual, ok := parseNotFixedYet(tt.comment)
+		if !ok {
+			t.Errorf("[%d]: no match: %s\n", i, tt.comment)
+			return
+		}
+		if !reflect.DeepEqual(tt.expected, *actual) {
+			e := pp.Sprintf("%v", tt.expected)
+			a := pp.Sprintf("%v", *actual)
+			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
+		}
+	}
+}
+
+func TestParseNotDecided(t *testing.T) {
+	var tests = []struct {
+		comment  string
+		expected Package
+	}{
+		{
+			comment: `libxerces-c-samples package in bionic is affected, but a decision has been made to defer addressing it (note: '2019-01-01').`,
+			expected: Package{
+				Name:        "libxerces-c-samples",
+				NotFixedYet: true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		actual, ok := parseNotDecided(tt.comment)
+		if !ok {
+			t.Errorf("[%d]: no match: %s\n", i, tt.comment)
+			return
+		}
+		if !reflect.DeepEqual(tt.expected, *actual) {
+			e := pp.Sprintf("%v", tt.expected)
+			a := pp.Sprintf("%v", *actual)
+			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
+		}
+	}
+}
+
+func TestParseFixed(t *testing.T) {
+	var tests = []struct {
+		comment  string
+		expected Package
+	}{
+		{
+			comment: `iproute2 package in bionic, is related to the CVE in some way and has been fixed (note: '3.12.0-2').`,
+			expected: Package{
+				Name:    "iproute2",
+				Version: "3.12.0-2",
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		actual, ok := parseFixed(tt.comment)
+		if !ok {
+			t.Errorf("[%d]: no match: %s\n", i, tt.comment)
+			return
+		}
+		if !reflect.DeepEqual(tt.expected, *actual) {
+			e := pp.Sprintf("%v", tt.expected)
+			a := pp.Sprintf("%v", *actual)
+			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
+		}
+	}
+}


### PR DESCRIPTION
OVAL format for Ubuntu has been changed.
Older versions of goval-dictionary cannot parse the new format of OVAL.
This cause the Uubntu scan results in Vuls is zero.
see  https://github.com/future-architect/vuls/issues/816

Vuls users who are scanning Ubuntu Linux have to update goval-dictionary.