### PR TITLE
Support Ubuntu 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ fetch-ubuntu:
                 [-log-json]
 
 For the first time, run the blow command to fetch data for all versions.
-    $ goval-dictionary fetch-ubuntu 12 14 16 18
+    $ goval-dictionary fetch-ubuntu 12 14 16 18 19
 
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/oval.sqlite3")
@@ -199,7 +199,7 @@ For the first time, run the blow command to fetch data for all versions.
 - Import OVAL data from Internet
 
 ```bash
-$ goval-dictionary fetch-ubuntu 12 14 16 18
+$ goval-dictionary fetch-ubuntu 12 14 16 18 19
 ```
 
 ### Usage: Fetch OVAL data from SUSE

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ const (
 	// Ubuntu18 is Ubuntu Bionic
 	Ubuntu18 = "bionic"
 
-	// Ubuntu 19 is Disco Dingo
+	// Ubuntu19 is Disco Dingo
 	Ubuntu19 = "disco"
 
 	// Debian7 is wheezy

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,9 @@ const (
 	// Ubuntu18 is Ubuntu Bionic
 	Ubuntu18 = "bionic"
 
+	// Ubuntu 19 is Disco Dingo
+	Ubuntu19 = "disco"
+
 	// Debian7 is wheezy
 	Debian7 = "wheezy"
 

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -34,6 +34,8 @@ func ubuntuName(major string) string {
 		return config.Ubuntu16
 	case "18":
 		return config.Ubuntu18
+	case "19":
+		return config.Ubuntu19
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
I believe this change should allow support for Ubuntu 19/ Disco Dingo.  OVAL data is published and available at the standard URL scheme for this version.