### PR TITLE
Add no-details for fetch-amazon 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ fetch-redhat:
                 [-debug]
                 [-debug-sql]
                 [-quiet]
+                [-no-details]
                 [-log-dir=/path/to/log]
                 [-log-json]
 
@@ -100,12 +101,14 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
-  -quiet
-        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -log-json
         output log as JSON
+  -no-details
+        without vulnerability details
+  -quiet
+        quiet mode (no output)
 ```
 
 - Import OVAL data from Internet
@@ -172,6 +175,7 @@ fetch-ubuntu:
                 [-debug]
                 [-debug-sql]
                 [-quiet]
+                [-no-details]
                 [-log-dir=/path/to/log]
                 [-log-json]
 
@@ -188,12 +192,14 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
-  -quiet
-        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -log-json
         output log as JSON
+  -no-details
+        without vulnerability details
+  -quiet
+        quiet mode (no output)
 ```
 
 - Import OVAL data from Internet
@@ -276,6 +282,7 @@ fetch-oracle:
                 [-debug]
                 [-debug-sql]
                 [-quiet]
+                [-no-details]
                 [-log-dir=/path/to/log]
                 [-log-json]
 
@@ -292,12 +299,14 @@ For the first time, run the blow command to fetch data for all versions.
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
-  -quiet
-        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -log-json
         output log as JSON
+  -no-details
+        without vulnerability details
+  -quiet
+        quiet mode (no output)
 ```
 
 - Import OVAL data from Internet
@@ -313,6 +322,7 @@ alpine-secdb is provided in YAML format and not OVAL, but it is supported by gov
 See [here](https://git.alpinelinux.org/cgit/alpine-secdb/tree/) for a list of supported alpines.
 
 ```bash
+$ goval-dictionary fetch-alpine -h
 fetch-alpine:
         fetch-alpine
                 [-dbtype=sqlite3|mysql|postgres|redis]
@@ -357,6 +367,7 @@ See [here](https://git.alpinelinux.org/cgit/alpine-secdb/tree/) for a list of su
 Amazon ALAS provideis Vulnerability data as `no-OVAL-format`, but it is supported by goval-dictionary to make Amazon ALAS easier to handle from Vuls.
 
 ```bash
+$ goval-dictionary fetch-amazon -h
 fetch-amazon:
         fetch-amazon
                 [-dbtype=sqlite3|mysql|postgres|redis]
@@ -365,6 +376,7 @@ fetch-amazon:
                 [-debug]
                 [-debug-sql]
                 [-quiet]
+                [-no-details]
                 [-log-dir=/path/to/log]
                 [-log-json]
 
@@ -384,6 +396,8 @@ fetch-amazon:
         /path/to/log (default "/var/log/vuls")
   -log-json
         output log as JSON
+  -no-details
+        without vulnerability details
   -quiet
         quiet mode (no output)
 ```

--- a/commands/fetch-amazon.go
+++ b/commands/fetch-amazon.go
@@ -22,6 +22,7 @@ type FetchAmazonCmd struct {
 	Debug     bool
 	DebugSQL  bool
 	Quiet     bool
+	NoDetails bool
 	LogDir    string
 	LogJSON   bool
 	DBPath    string
@@ -45,6 +46,7 @@ func (*FetchAmazonCmd) Usage() string {
 		[-debug]
 		[-debug-sql]
 		[-quiet]
+		[-no-details]
 		[-log-dir=/path/to/log]
 		[-log-json]
 
@@ -57,6 +59,7 @@ func (p *FetchAmazonCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.Debug, "debug", false, "debug mode")
 	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
 	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
+	f.BoolVar(&p.NoDetails, "no-details", false, "without vulnerability details")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -85,6 +88,7 @@ func (p *FetchAmazonCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 	c.Conf.DBPath = p.DBPath
 	c.Conf.DBType = p.DBType
 	c.Conf.HTTPProxy = p.HTTPProxy
+	c.Conf.NoDetails = p.NoDetails
 
 	util.SetLogger(p.LogDir, c.Conf.Quiet, c.Conf.Debug, p.LogJSON)
 	if !c.Conf.Validate() {

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -66,7 +66,7 @@ func (p *FetchOracleCmd) SetFlags(f *flag.FlagSet) {
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
-	f.BoolVar(&p.LogJSON, "log-json", false, "output log as json")
+	f.BoolVar(&p.LogJSON, "log-json", false, "output log as JSON")
 
 	pwd := os.Getenv("PWD")
 	f.StringVar(&p.DBPath, "dbpath", pwd+"/oval.sqlite3",

--- a/models/amazon.go
+++ b/models/amazon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	c "github.com/kotakanbe/goval-dictionary/config"
 	"github.com/kotakanbe/goval-dictionary/fetcher"
 )
 
@@ -35,7 +36,7 @@ func ConvertAmazonToModel(data *fetcher.UpdateInfo) (defs []Definition) {
 			})
 		}
 
-		defs = append(defs, Definition{
+		def := Definition{
 			DefinitionID:  "def-" + alas.ID,
 			Title:         alas.ID,
 			Description:   alas.Description,
@@ -46,7 +47,14 @@ func ConvertAmazonToModel(data *fetcher.UpdateInfo) (defs []Definition) {
 				Updated:  updatedAt,
 			},
 			References: refs,
-		})
+		}
+
+		if c.Conf.NoDetails {
+			def.Description = ""
+			def.References = []Reference{}
+		}
+
+		defs = append(defs, def)
 	}
 	return
 }


### PR DESCRIPTION
# TODO: 

- [x] Add -no-details option for fetch-amazon command
- [x] Update README.md 

# Test

```
$ cat amazon2.jzon | jq . 
{
  "Family": "amazon",
  "Release": "2 (Karoo)",
  "RunningKernel": {
    "Release": "4.14.121-109.96.amzn2.x86_64",
    "Version": ""
  },
  "Packages": {
    "kernel": {
      "Name": "kernel",
      "Version": "4.14.114",
      "Release": "105.126.amzn2",
      "Arch": "x86_64"
    },
    "dracut": {
      "Name": "dracut",
      "Version": "033",
      "Release": "535.amzn2.1.2",
      "Arch": "x86_64"
    }
  }
}
```

```
$ : check init redis size 
$ redis-cli info  | grep used_memory_human 
used_memory_human:833.74K

$ : fetch amazon linux oval
$ ./goval-dictionary fetch-amazon -dbtype=redis -dbpath=redis://localhost:6379
$ redis-cli info  | grep used_memory_human 
used_memory_human:39.46M

$ curl -X POST -H "Content-Type: application/json" -d @amazon2.json http://localhost:5515/vuls
[Jun 25 14:30:22]  INFO [localhost] : 0 CVEs are detected with Library
[Jun 25 14:30:22]  INFO [localhost] OVAL is fresh: amazon 2 (Karoo)
[Jun 25 14:30:22]  INFO [localhost] : 8 CVEs are detected with OVAL
[Jun 25 14:30:22]  INFO [localhost] : 0 CVEs are detected with CPE
[Jun 25 14:30:22]  INFO [localhost] : 0 CVEs are detected with GitHub Security Alerts
[Jun 25 14:30:22]  INFO [localhost] : 0 unfixed CVEs are detected with gost
[Jun 25 14:30:22]  INFO [localhost] Fill CVE detailed information with CVE-DB
[Jun 25 14:30:22]  INFO [localhost] Fill exploit information with Exploit-DB
[Jun 25 14:30:22]  INFO [localhost] : 0 exploits are detected
[Jun 25 14:30:22]  INFO [localhost] : en: 0, ja: 0 alerts are detected

--- # test no-details
$ docker rm -f redis 
$ docker run --name redis -p 6379:6379 -d redis:5.0-alpine3.8
$ redis-cli info  | grep used_memory_human 
used_memory_human:833.74K

$ : fetch amazon linux oval -no-details
$ ./goval-dictionary fetch-amazon -dbtype=redis -dbpath=redis://localhost:6379 -no-details
$ redis-cli info  | grep used_memory_human 
used_memory_human:20.10M

$ curl -X POST -H "Content-Type: application/json" -d @amazon2.json http://localhost:5515/vuls
[Jun 25 14:32:43]  INFO [localhost] : 0 CVEs are detected with Library
[Jun 25 14:32:43]  INFO [localhost] OVAL is fresh: amazon 2 (Karoo)
[Jun 25 14:32:43]  INFO [localhost] : 8 CVEs are detected with OVAL
[Jun 25 14:32:43]  INFO [localhost] : 0 CVEs are detected with CPE
[Jun 25 14:32:43]  INFO [localhost] : 0 CVEs are detected with GitHub Security Alerts
[Jun 25 14:32:43]  INFO [localhost] : 0 unfixed CVEs are detected with gost
[Jun 25 14:32:43]  INFO [localhost] Fill CVE detailed information with CVE-DB
[Jun 25 14:32:43]  INFO [localhost] Fill exploit information with Exploit-DB
[Jun 25 14:32:43]  INFO [localhost] : 0 exploits are detected
[Jun 25 14:32:43]  INFO [localhost] : en: 0, ja: 0 alerts are detected
```