### PR TITLE
Vuls in server mode: arch param is optional for goval

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,7 @@ func Start(logDir string) error {
 	// Routes
 	e.GET("/health", health())
 	e.GET("/packs/:family/:release/:pack/:arch", getByPackName())
+	e.GET("/packs/:family/:release/:pack", getByPackName())
 	e.GET("/count/:family/:release", countOvalDefs())
 	e.GET("/lastmodified/:family/:release", getLastModified())
 	//  e.Post("/cpes", getByPackName())


### PR DESCRIPTION
Vuls in server mode calls the goval component with an optional arch param, so goval must support an url endpoint without this param.
Else following error when vuls generates a json report:
"Failed to fill with OVAL: Failed to fetch OVAL. err: [%!w(*xerrors.errorString)] "
