### PR TITLE
Add debian no details option for debian.

### DIFF
--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -24,6 +24,7 @@ type FetchDebianCmd struct {
 	Debug     bool
 	DebugSQL  bool
 	Quiet     bool
+	NoDetails bool
 	LogDir    string
 	LogJSON   bool
 	DBPath    string
@@ -47,6 +48,7 @@ func (*FetchDebianCmd) Usage() string {
 		[-debug]
 		[-debug-sql]
 		[-quiet]
+		[-no-details]
 		[-log-dir=/path/to/log]
 		[-log-json]
 
@@ -61,6 +63,7 @@ func (p *FetchDebianCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.Debug, "debug", false, "debug mode")
 	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
 	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
+	f.BoolVar(&p.NoDetails, "no-details", false, "without vulnerability details")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -89,6 +92,7 @@ func (p *FetchDebianCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 	c.Conf.DBPath = p.DBPath
 	c.Conf.DBType = p.DBType
 	c.Conf.HTTPProxy = p.HTTPProxy
+	c.Conf.NoDetails = p.NoDetails
 
 	util.SetLogger(p.LogDir, c.Conf.Quiet, c.Conf.Debug, p.LogJSON)
 	if !c.Conf.Validate() {

--- a/models/debian.go
+++ b/models/debian.go
@@ -46,6 +46,19 @@ func ConvertDebianToModel(root *oval.Root) (defs []Definition) {
 				def.Title = ""
 				def.Description = ""
 				def.Advisory = Advisory{}
+
+				var references []Reference
+				for _, ref := range def.References {
+					if ref.Source != "CVE" {
+						continue
+					}
+					references = append(references, Reference{
+						Source: ref.Source,
+						RefID:  ref.RefID,
+					})
+				}
+				def.Debian.MoreInfo = ""
+				def.References = references
 			}
 
 			defs = append(defs, def)

--- a/models/debian.go
+++ b/models/debian.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	c "github.com/kotakanbe/goval-dictionary/config"
 	"github.com/ymomoi/goval-parser/oval"
 )
 
@@ -40,6 +41,13 @@ func ConvertDebianToModel(root *oval.Root) (defs []Definition) {
 				AffectedPacks: []Package{distPack.pack},
 				References:    rs,
 			}
+
+			if c.Conf.NoDetails {
+				def.Title = ""
+				def.Description = ""
+				def.Advisory = Advisory{}
+			}
+
 			defs = append(defs, def)
 		}
 	}


### PR DESCRIPTION
Add no details command for debian.

```
# Before 
$  ./goval-dictionary fetch-debian -dbtype redis -dbpath redis://localhost:6379/1 7 8 9
$ redis-cli -c info memory  | grep used_memory_human
used_memory_human:38.24M

# After 
$  ./goval-dictionary fetch-debian --no-details -dbtype redis -dbpath redis://localhost:6379/1 7 8 9
$ redis-cli -c info memory  | grep used_memory_human
used_memory_human:26.15M
```