### PR TITLE
Support ubuntu20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ fetch-ubuntu:
                 [-log-json]
 
 For the first time, run the blow command to fetch data for all versions.
-    $ goval-dictionary fetch-ubuntu 12 14 16 18 19
+    $ goval-dictionary fetch-ubuntu 12 14 16 18 19 20
 
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/oval.sqlite3")
@@ -205,7 +205,7 @@ For the first time, run the blow command to fetch data for all versions.
 - Import OVAL data from Internet
 
 ```bash
-$ goval-dictionary fetch-ubuntu 12 14 16 18 19
+$ goval-dictionary fetch-ubuntu 12 14 16 18 19 20
 ```
 
 ### Usage: Fetch OVAL data from SUSE

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,9 @@ const (
 	// Ubuntu19 is Disco Dingo
 	Ubuntu19 = "disco"
 
+	// Ubuntu20 is  Focal Fossa
+	Ubuntu20 = "focal"
+
 	// Debian7 is wheezy
 	Debian7 = "wheezy"
 

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -39,6 +39,8 @@ func ubuntuName(major string) string {
 		return config.Ubuntu18
 	case "19":
 		return config.Ubuntu19
+	case "20":
+		return config.Ubuntu20
 	default:
 		return "unknown"
 	}

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kotakanbe/goval-dictionary v0.2.5 h1:wae0zFw4UnakJaApdxwWgw+QDE7dWP4AeDPtMencPN4=
+github.com/kotakanbe/goval-dictionary v0.2.5/go.mod h1:OozI5ZbKWHIPcjYgOITYHRy+Vo6ZbksY1FU8aCwojK4=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=


### PR DESCRIPTION
# Contents of change
- Fetch OVAL data on Ubuntu20.04
#84 is reference issue

# File changes
- config.go
    - add code name of ubuntu20.04
- ubuntu.go
    - add case ubuntu20.04
- Readme.md
    - Add to use fetch OVAL data on Ubuntu 20.04

# Using ```goval-dictionary fetch-ubuntu 20```
![image](https://user-images.githubusercontent.com/39241071/82625143-5a3ba900-9c1f-11ea-89dd-d0f434336868.png)

Created oval.sqlite3
![image](https://user-images.githubusercontent.com/39241071/82625348-d930e180-9c1f-11ea-96d8-2623e367fe12.png)

Check oval.sqlite3
![image](https://user-images.githubusercontent.com/39241071/82625407-fbc2fa80-9c1f-11ea-8fa8-9f9d31b2f4c9.png)