### PR TITLE
Fix terminated in a panic when permission error 

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -58,10 +58,15 @@ func SetLogger(logDir string, quiet, debug, logJSON bool) {
 	var hundler log15.Handler
 	if _, err := os.Stat(logDir); err == nil {
 		logPath := filepath.Join(logDir, "goval-dictionary.log")
-		hundler = log15.MultiHandler(
-			log15.Must.FileHandler(logPath, logFormat),
-			lvlHundler,
-		)
+		if err := ioutil.WriteFile(logPath, []byte{}, 0700); err != nil {
+			log15.Error("Failed to create a log file", "err", err)
+			hundler = lvlHundler
+		} else {
+			hundler = log15.MultiHandler(
+				log15.Must.FileHandler(logPath, logFormat),
+				lvlHundler,
+			)
+		}
 	} else {
 		hundler = lvlHundler
 	}


### PR DESCRIPTION
# What did you implement:
Prevented the program from terminating in a panic if permission error occurs when goval-dictionary writes to the log file.

Fixes #83 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Output of fix goval-dictionary
- Permission set 400 of /var/log/vuls
- exec goval-dictionary fetch-ubuntu 20

![image (1)](https://user-images.githubusercontent.com/39241071/85098582-1c3d9f00-b236-11ea-8aec-08449a83cb7b.png)
![image (2)](https://user-images.githubusercontent.com/39241071/85098579-1b0c7200-b236-11ea-9530-9509b005cefd.png)

# Reference

* https://github.com/kotakanbe/go-cve-dictionary/blob/master/log/log.go

