### PR TITLE
Fix get ubuntu oval data

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ fetch-ubuntu:
                 [-log-dir=/path/to/log]
                 [-log-json]
 
-For the first time, run the blow command to fetch data for all versions.
-    $ goval-dictionary fetch-ubuntu 12 14 16 18 19 20
+For the first time, run the below command to fetch data for all versions.
+    $ goval-dictionary fetch-ubuntu 14 16 18 19 20
 
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/oval.sqlite3")
@@ -205,7 +205,7 @@ For the first time, run the blow command to fetch data for all versions.
 - Import OVAL data from Internet
 
 ```bash
-$ goval-dictionary fetch-ubuntu 12 14 16 18 19 20
+$ goval-dictionary fetch-ubuntu 14 16 18 19 20
 ```
 
 ### Usage: Fetch OVAL data from SUSE

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -51,8 +51,8 @@ func (*FetchUbuntuCmd) Usage() string {
 		[-log-dir=/path/to/log]
 		[-log-json]
 
-For the first time, run the blow command to fetch data for all versions.
-	$ goval-dictionary fetch-ubuntu 12 14 16 18
+For the first time, run the below command to fetch data for all versions.
+	$ goval-dictionary fetch-ubuntu 14 16 18 19 20
 
 `
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,23 +18,17 @@ const (
 	// Ubuntu is
 	Ubuntu = "ubuntu"
 
-	// Ubuntu12 is Ubuntu Precise
-	Ubuntu12 = "precise"
-
 	// Ubuntu14 is Ubuntu Trusty
 	Ubuntu14 = "trusty"
 
 	// Ubuntu16 is Ubuntu Xenial
 	Ubuntu16 = "xenial"
 
-	// Ubuntu17 is Ubuntu Artful
-	Ubuntu17 = "artful"
-
 	// Ubuntu18 is Ubuntu Bionic
 	Ubuntu18 = "bionic"
 
-	// Ubuntu19 is Disco Dingo
-	Ubuntu19 = "disco"
+	// Ubuntu19 is Eoan Ermine
+	Ubuntu19 = "eoan"
 
 	// Ubuntu20 is  Focal Fossa
 	Ubuntu20 = "focal"

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -14,7 +14,7 @@ func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
 		if name = ubuntuName(v); name == "unknown" {
 			log15.Warn("Skip unknown ubuntu.", "version", v)
 			continue
-		} else if ubuntuName(v); name == "unsupported" {
+		} else if name = ubuntuName(v); name == "unsupported" {
 			log15.Warn("Skip unsupported ubuntu version.", "version", v)
 			log15.Warn("See https://wiki.ubuntu.com/Releases for supported versions")
 			continue

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -14,6 +14,10 @@ func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
 		if name = ubuntuName(v); name == "unknown" {
 			log15.Warn("Skip unknown ubuntu.", "version", v)
 			continue
+		} else if ubuntuName(v); name == "unsupported" {
+			log15.Warn("Skip unsupported ubuntu version.", "version", v)
+			log15.Warn("See https://wiki.ubuntu.com/Releases for supported versions")
+			continue
 		}
 		reqs = append(reqs, fetchRequest{
 			target:       v,
@@ -28,13 +32,13 @@ func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
 func ubuntuName(major string) string {
 	switch major {
 	case "12":
-		return config.Ubuntu12
+		return "unsupported"
 	case "14":
 		return config.Ubuntu14
 	case "16":
 		return config.Ubuntu16
 	case "17":
-		return config.Ubuntu17
+		return "unsupported"
 	case "18":
 		return config.Ubuntu18
 	case "19":


### PR DESCRIPTION
# What did you implement:
- Fix an error whene we get OVAL data of Ubuntu19
- Unsupport to get OVAL data of Ubuntu12, 17
  - Because end of life ubuntu12,17 (If you want to know detail, please check reference URL)

Fixes #91 

## Output
- Using ```goval-dictionary fetch-ubuntu 19```
<img width="777" alt="キャプチャ" src="https://user-images.githubusercontent.com/39241071/85106574-64b18880-b247-11ea-9b12-a8724c118fb7.PNG">
<img width="422" alt="キャプチャ1" src="https://user-images.githubusercontent.com/39241071/85106587-68dda600-b247-11ea-9e1e-ddbec7088808.PNG">

- Using ```goval-dictionary fetch-ubuntu unsupported version```
<img width="454" alt="キャプチャ3" src="https://user-images.githubusercontent.com/39241071/85106736-a8a48d80-b247-11ea-860a-b046e5d58b69.PNG">


## Reference
https://wiki.ubuntu.com/Releases