### PR TITLE
fix select command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,11 +414,11 @@ Select from DB where package name is golang.
 
 <details>
 <summary>
-`$ goval-dictionary select -by-package redhat 7 golang`
+`$ goval-dictionary select -by-package redhat 7 golang x86_64`
 </summary>
 
 ```bash
-$ goval-dictionary select -by-package redhat 7 golang
+$ goval-dictionary select -by-package redhat 7 golang x86_64
 [Apr 10 10:22:43]  INFO Opening DB (sqlite3).
 CVE-2015-5739
     {3399 319 golang 0:1.6.3-1.el7_2.1}

--- a/commands/select.go
+++ b/commands/select.go
@@ -78,14 +78,18 @@ func (p *SelectCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	c.Conf.DBType = p.DBType
 
 	util.SetLogger(p.LogDir, c.Conf.Quiet, c.Conf.Debug, p.LogJSON)
-	if f.NArg() != 3 {
+	if p.ByPackage && f.NArg() != 4 {
 		log15.Crit(`
 		Usage:
 		select OVAL by package name
-		./goval-dictionary select -by-package RedHat 7 java-1.7.0-openjdk x86_64
+		./goval-dictionary select -by-package redhat 7 java-1.7.0-openjdk x86_64
+		`)
+	}
 
+	if p.ByCveID && f.NArg() != 3 {
+		log15.Crit(`
 		select OVAL by CVE-ID
-		./goval-dictionary select -by-cveid RedHat 7 CVE-2015-1111
+		./goval-dictionary select -by-cveid redhat 7 CVE-2015-1111
 		`)
 	}
 


### PR DESCRIPTION
# What did you implement:

The contents changed in 0e718b4 were not applied to README.md and argument check, so it was corrected.

Fixes #97 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I ran the following command.
Since there is much CVE information on chromium, it is omitted.

```bash
$ ./goval-dictionary select -by-package debian 10 chromium x86_64
...
models.Definition{
    ID:           0x3ff9,
    RootID:       0x1,
    DefinitionID: "oval:org.debian:def:20206504",
    Title:        "CVE-2020-6504",
    Description:  "Insufficient policy enforcement in notifications in Google Chrome prior to 74.0.3729.108 allowed a remote attacker to bypass notification restrictions via a crafted HTML page.",
    Advisory:     models.Advisory{
      ID:              0x0,
      DefinitionID:    0x0,
      Severity:        "",
      Cves:            []models.Cve{},
      Bugzillas:       []models.Bugzilla{},
      AffectedCPEList: []models.Cpe{},
      Issued:          1-01-01 00:00:00 UTC,
      Updated:         1-01-01 00:00:00 UTC,
    },
    Debian: models.Debian{
      ID:           0x3ff9,
      DefinitionID: 0x3ff9,
      CveID:        "CVE-2020-6504",
      MoreInfo:     "",
      Date:         2020-06-25 00:00:00 UTC,
    },
    AffectedPacks: []models.Package{
      models.Package{
        ID:           0x3ff9,
        DefinitionID: 0x3ff9,
        Name:         "chromium",
        Version:      "76.0.3809.100-1~deb10u1",
        Arch:         "",
        NotFixedYet:  false,
      },
    },
    References: []models.Reference{
      models.Reference{
        ID:           0x3d67,
        DefinitionID: 0x3ff9,
        Source:       "CVE",
        RefID:        "CVE-2020-6504",
        RefURL:       "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-6504",
      },
    },
...
```

I confirmed that the argument check is performed.
According to the existing implementation, the log is displayed by CRIT instead of ERROR.

```bash
$ ./goval-dictionary select -by-package debian 10 chromium
CRIT[06-26|02:21:56]
                Usage:
                select OVAL by package name
                ./goval-dictionary select -by-package redhat 7 java-1.7.0-openjdk x86_64

panic: runtime error: index out of range [3] with length 3

goroutine 1 [running]:
github.com/kotakanbe/goval-dictionary/commands.(*SelectCmd).Execute(0xc0002df630, 0xbf2f20, 0xc00011a000, 0xc0003045a0, 0x0, 0x0, 0x0, 0x1040800)
        /home/mainek00n/github/github.com/MaineK00n/goval-dictionary/commands/select.go:117 +0x9e3
github.com/google/subcommands.(*Commander).Execute(0xc000130000, 0xbf2f20, 0xc00011a000, 0x0, 0x0, 0x0, 0xc00034e580)
        /home/mainek00n/go/1.14.3/pkg/mod/github.com/google/subcommands@v1.0.1/subcommands.go:142 +0x2f9
github.com/google/subcommands.Execute(...)
        /home/mainek00n/go/1.14.3/pkg/mod/github.com/google/subcommands@v1.0.1/subcommands.go:420
main.main()
        /home/mainek00n/github/github.com/MaineK00n/goval-dictionary/main.go:55 +0x461

$ ./goval-dictionary select -by-cveid debian 10 CVE-2020-6509 test
CRIT[06-26|02:22:36]
                select OVAL by CVE-ID
                ./goval-dictionary select -by-cveid redhat 7 CVE-2015-1111
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

