### PR TITLE
change Raspbian use Debian OVAL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,9 @@ const (
 	// Ubuntu is
 	Ubuntu = "ubuntu"
 
+	// Raspbian is
+	Raspbian = "raspbian"
+
 	// Ubuntu14 is Ubuntu Trusty
 	Ubuntu14 = "trusty"
 

--- a/db/rdb/rdb.go
+++ b/db/rdb/rdb.go
@@ -194,10 +194,10 @@ func (d *Driver) CloseDB() (err error) {
 
 // GetByPackName select OVAL definition related to OS Family, osVer, packName
 func (d *Driver) GetByPackName(family, osVer, packName, arch string) ([]models.Definition, error) {
-	if family == c.CentOS {
+	switch family {
+	case c.CentOS:
 		family = c.RedHat
-	}
-	if family == c.Raspbian {
+	case c.Raspbian:
 		family = c.Debian
 	}
 

--- a/db/rdb/rdb.go
+++ b/db/rdb/rdb.go
@@ -197,6 +197,10 @@ func (d *Driver) GetByPackName(family, osVer, packName, arch string) ([]models.D
 	if family == c.CentOS {
 		family = c.RedHat
 	}
+	if family == c.Raspbian {
+		family = c.Debian
+	}
+
 	if _, ok := ovalMap[family]; !ok {
 		return nil, fmt.Errorf("Unsupport family: %s", family)
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -124,8 +124,11 @@ func (d *RedisDriver) CloseDB() (err error) {
 
 // GetByPackName select OVAL definition related to OS Family, osVer, packName, arch
 func (d *RedisDriver) GetByPackName(family, osVer, packName, arch string) (defs []models.Definition, err error) {
-	if family == c.CentOS {
+	switch family {
+	case c.CentOS:
 		family = c.RedHat
+	case c.Raspbian:
+		family = c.Debian
 	}
 
 	// Alpne provides vulnerability file for each major.minor


### PR DESCRIPTION
# What did you implement:

OVAL uses Debian when family is Raspbian.

Fixes https://github.com/future-architect/vuls/issues/1001

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The test result confirms the use of OVAL in this PR.
https://github.com/future-architect/vuls/pull/1019

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
- https://github.com/future-architect/vuls/issues/1001
- https://github.com/future-architect/vuls/pull/1019

