### PR TITLE
Use detected SuSE type instead of opensuse when inserting oval data

### DIFF
--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -191,7 +191,7 @@ func (p *FetchSUSECmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfac
 		roots := models.ConvertSUSEToModel(&ovalroot, suseType)
 		for _, root := range roots {
 			root.Timestamp = time.Now()
-			if err := driver.InsertOval(c.OpenSUSE, &root, fmeta); err != nil {
+			if err := driver.InsertOval(suseType, &root, fmeta); err != nil {
 				log15.Error("Failed to insert oval", "err", err)
 				return subcommands.ExitFailure
 			}


### PR DESCRIPTION
# What did you implement:

command "goval fetch-suse" for SLES is not working

When using 

`goval-dictionary fetch-suse -suse-enterprise-server 12`

OVALs are downloaded from suse website but then i  got "Unsuport family: opensuse" message when inserting then in the database, like #100 and #86 issues

after this change i was able to fetch sles OVALs and was also able to use vuls to analyze SLES vulnerabilities (I'll open an issue to document it on vuls side after)

Fixes #100 #86 (at least I think ;) )

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After the fix I can now fetch ovals for SLES 11 12 and 15 

```
goval-dictionary fetch-suse -suse-enterprise-server 11
goval-dictionary fetch-suse -suse-enterprise-server 12
goval-dictionary fetch-suse -suse-enterprise-server 15
```

And I can check packages on my sles system by using vuls API like this

```
curl 'http://localhost:5515/vuls'  -H 'Content-Type: application/json'  --data '{ "family" : "suse.linux.enterprise.server", "release" : "12.1", "packages" : { "openssl" : { "name" : "openssl", "version" : "1.0.1i-34.1", "arch" : "x86_64"} } }
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

