### PR TITLE
fix(suse): OVAL for SLES provided in earch major version

### DIFF
--- a/db/rdb/rdb.go
+++ b/db/rdb/rdb.go
@@ -251,8 +251,6 @@ func (d *Driver) CountDefs(osFamily, osVer string) (int, error) {
 	switch osFamily {
 	case c.Alpine:
 		osVer = majorDotMinor(osVer)
-	case c.SUSEEnterpriseServer:
-		// SUSE provides OVAL each major.minor
 	case c.Amazon:
 		osVer = getAmazonLinux1or2(osVer)
 	default:
@@ -277,8 +275,6 @@ func (d *Driver) GetLastModified(osFamily, osVer string) time.Time {
 	switch osFamily {
 	case c.Alpine:
 		osVer = majorDotMinor(osVer)
-	case c.SUSEEnterpriseServer:
-		// SUSE provides OVAL each major.minor
 	case c.Amazon:
 		osVer = getAmazonLinux1or2(osVer)
 	default:

--- a/db/rdb/suse.go
+++ b/db/rdb/suse.go
@@ -6,6 +6,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/jinzhu/gorm"
 	"github.com/k0kubun/pp"
+	c "github.com/kotakanbe/goval-dictionary/config"
 	"github.com/kotakanbe/goval-dictionary/models"
 )
 
@@ -73,9 +74,16 @@ func (o *SUSE) InsertOval(root *models.Root, meta models.FetchMeta, driver *gorm
 }
 
 // GetByPackName select definitions by packName
-// SUSE : OVAL is separate for each minor version. So select OVAL by major.minimor version.
-// http: //ftp.suse.com/pub/projects/security/oval/
 func (o *SUSE) GetByPackName(driver *gorm.DB, osVer, packName, _ string) ([]models.Definition, error) {
+	// SLES: OVAL provided in each major version.
+	// OpenSUSE : OVAL is separate for each minor version.
+	// http://ftp.suse.com/pub/projects/security/oval/
+	switch o.Family {
+	case c.SUSEEnterpriseServer,
+		c.SUSEEnterpriseDesktop,
+		c.SUSEOpenstackCloud:
+		osVer = major(osVer)
+	}
 	packs := []models.Package{}
 	err := driver.Where(&models.Package{Name: packName}).Find(&packs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {


### PR DESCRIPTION
I don't know since when, but SLES OVAL is provided for each major version instead of major.minor.
http://ftp.suse.com/pub/projects/security/oval/

I scanned and report SLES15.2, and got the following error.

```
[Sep 28 16:04:37]  INFO [localhost] sles: 0 CVEs are detected with Library
[Sep 28 16:04:37] ERROR [localhost] Failed to fill with OVAL: OVAL entries of suse.linux.enterprise.server 15.2 are not found. Fetch OVAL before reporting. For details, see `https://github.com/kotakanbe/goval-dictionary#usage`
```
