### PR TITLE
fix(debian): use Debian.CveID when refs is empty #107

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.32

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v1
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.26
+          version: v1.32
           
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
# What did you implement:

Fixes #107 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

before
```
./goval-dictionary   fetch-debian  -debug  -dbtype redis -dbpath "redis://localhost/0" 9
DBUG[11-18|07:16:09] Opening DB.                              db=redis
INFO[11-18|07:16:09] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[11-18|07:16:12] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[11-18|07:16:12] Finished fetching OVAL definitions 
INFO[11-18|07:16:15] Fetched                                  URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml OVAL definitions=22871
INFO[11-18|07:16:17] Total CVE-IDs:                           count=16523
```

after
```
go build; and ./goval-dictionary   fetch-debian  -debug  -dbtype redis -dbpath "redis://localhost/0" 9
DBUG[11-18|07:16:42] Opening DB.                              db=redis
INFO[11-18|07:16:42] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[11-18|07:16:43] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[11-18|07:16:43] Finished fetching OVAL definitions 
INFO[11-18|07:16:47] Fetched                                  URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml OVAL definitions=22871
INFO[11-18|07:16:48] Total CVE-IDs:                           count=16544
```


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES