### PR TITLE
fix(debian): false negative of kernel cves with rdb backend

### DIFF
--- a/db/rdb/alpine.go
+++ b/db/rdb/alpine.go
@@ -90,7 +90,7 @@ func (o *Alpine) GetByPackName(driver *gorm.DB, osVer, packName, _ string) (defs
 			Preload("Advisory.Cves").
 			Preload("AffectedPacks").
 			Preload("References").
-			Find(&defs).Error
+			Find(&tmpDefs).Error
 
 		if err != nil && err != gorm.ErrRecordNotFound {
 			return nil, err

--- a/db/rdb/debian.go
+++ b/db/rdb/debian.go
@@ -123,7 +123,7 @@ func (o *Debian) GetByPackName(driver *gorm.DB, osVer, packName, _ string) (defs
 			Preload("Debian").
 			Preload("AffectedPacks").
 			Preload("References").
-			Find(&defs).Error
+			Find(&tmpDefs).Error
 
 		if err != nil && err != gorm.ErrRecordNotFound {
 			return nil, err


### PR DESCRIPTION
# What did you implement:

A false negative in Debian's kernel vulnerability has been fixed.
In Debian's OVAL, kernel vulnerabilities are defined as "linux".
Due to a bug in the RDB oval driver, no more than 998 vulnerabilities were obtained.
cve-ids related "linux" defined after 999 was not possible to detect.
This bug affects the case of RDB backend with scanning Debian.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

before
```
sqlite3
[Nov 18 08:30:15]  INFO [localhost] deb9: 6 CVEs are detected with OVAL
redis
[Nov 18 08:31:08]  INFO [localhost] deb9: 48 CVEs are detected with OVAL
```

after
```
sqlite3
[Nov 18 09:28:23]  INFO [localhost] deb9: 48 CVEs are detected with OVAL
```

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 
