### PR TITLE
Debian oval definitions are not updated

### DIFF
--- a/db/rdb/alpine.go
+++ b/db/rdb/alpine.go
@@ -33,7 +33,7 @@ func (o *Alpine) InsertOval(root *models.Root, meta models.FetchMeta, driver *go
 	old := models.Root{}
 	r := tx.Where(&models.Root{Family: root.Family, OSVersion: root.OSVersion}).First(&old)
 	if !r.RecordNotFound() {
-		// Delete data related to root passed in arg
+
 		defs := []models.Definition{}
 		tx.Model(&old).Related(&defs, "Definitions")
 		for _, def := range defs {


### PR DESCRIPTION
# What did you implement:

Oval definitions are not refreshed when fetching Debian OVALs. First fetch if correct and data are correctly inserted but if you run `goval-dictionary fetch-debian 10` later, nothing is update. Date of definitions is still the same (leading to a warning telling that OVAL definitions/roots are outdated) and data are not inserted. 

I noted that debian insertion is different from other systems, and we could apply the same logic here than other systems.

With this PR, I can now detect new CVE on debian, and the definitions are updated accordingly 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I'm running a Vuls instance and now i can detect updated CVE on debian systems, and i don't have OVAL Definitions outdated message anyore

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

