### PR TITLE
fix(ubuntu): Fix deferred packages not showing as affected

### DIFF
--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -129,7 +129,7 @@ func parseNotFixedYet(comment string) (*Package, bool) {
 	return nil, false
 }
 
-var reNotDecided = regexp.MustCompile(`^(.+) package in .+ is affected, but a decision has been made to defer addressing it .+$`)
+var reNotDecided = regexp.MustCompile(`^(.+) package in .+ is affected, but a decision has been made to defer addressing it.*$`)
 
 func parseNotDecided(comment string) (*Package, bool) {
 	// Ubuntu 14

--- a/models/ubuntu_test.go
+++ b/models/ubuntu_test.go
@@ -65,6 +65,13 @@ func TestParseNotDecided(t *testing.T) {
 				NotFixedYet: true,
 			},
 		},
+		{
+			comment: `systemd package in bionic is affected, but a decision has been made to defer addressing it.`,
+			expected: Package{
+				Name:        "systemd",
+				NotFixedYet: true,
+			},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
# What did you implement:

Hey there,

Please feel free to correct me if I'm wrong here as I'm new to this but deferred packages should be affected, no?
for example I used the Ubuntu 18 OVAL  and specifically: 
`<definition class="vulnerability" id="oval:com.ubuntu.bionic:def:2018208390000000" version="1">`

Which has the criteria: 
`<criterion test_ref="oval:com.ubuntu.bionic:tst:2018208390000000" comment="systemd package in bionic is affected, but a decision has been made to defer addressing it." />`

and it does not pass the not decided regex:
```go
var reNotDecided = regexp.MustCompile(`^(.+) package in .+ is affected, but a decision has been made to defer addressing it  .+$`)
```

So I changed the RE to catch the shown case above.

I hope my understanding here is correct.
Thanks!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a test

# Checklist:
You don't have to satisfy all of the following.

- [X] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [ ] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

