### PR TITLE
fix(oracle): collect arch info in OVAL

### DIFF
--- a/commands/select.go
+++ b/commands/select.go
@@ -121,6 +121,7 @@ func (p *SelectCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 			}
 		}
 		fmt.Println("------------------")
+		pp.ColoringEnabled = false
 		_, _ = pp.Println(dfs)
 		return subcommands.ExitSuccess
 	}
@@ -135,6 +136,7 @@ func (p *SelectCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 			fmt.Printf("%v\n", d.Advisory.Cves)
 		}
 		fmt.Println("------------------")
+		pp.ColoringEnabled = false
 		_, _ = pp.Println(dfs)
 		return subcommands.ExitSuccess
 	}

--- a/db/rdb/oracle.go
+++ b/db/rdb/oracle.go
@@ -39,7 +39,10 @@ func (o *Oracle) InsertOval(root *models.Root, meta models.FetchMeta, driver *go
 	log15.Info("Refreshing...", "Family", root.Family, "Version", root.OSVersion)
 
 	old := models.Root{}
-	r = tx.Where(&models.Root{Family: root.Family, OSVersion: root.OSVersion}).First(&old)
+	r = tx.Where(&models.Root{
+		Family:    root.Family,
+		OSVersion: root.OSVersion,
+	}).First(&old)
 	if !r.RecordNotFound() {
 		// Delete data related to root passed in arg
 		defs := []models.Definition{}
@@ -84,10 +87,13 @@ func (o *Oracle) InsertOval(root *models.Root, meta models.FetchMeta, driver *go
 }
 
 // GetByPackName select definitions by packName
-func (o *Oracle) GetByPackName(driver *gorm.DB, osVer, packName, _ string) ([]models.Definition, error) {
+func (o *Oracle) GetByPackName(driver *gorm.DB, osVer, packName, arch string) ([]models.Definition, error) {
 	osVer = major(osVer)
 	packs := []models.Package{}
-	err := driver.Where(&models.Package{Name: packName}).Find(&packs).Error
+	err := driver.Where(&models.Package{
+		Name: packName,
+		Arch: arch,
+	}).Find(&packs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, err
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -43,7 +43,7 @@ type Package struct {
 
 	Name            string
 	Version         string // affected earlier than this version
-	Arch            string // Used for Amazon Linux
+	Arch            string // Used for Amazon and Oracle Linux
 	NotFixedYet     bool   // Ubuntu Only
 	ModularityLabel string // RHEL 8 or later only
 }

--- a/server/server.go
+++ b/server/server.go
@@ -27,12 +27,12 @@ func Start(logDir string) error {
 	logPath := filepath.Join(logDir, "access.log")
 	if _, err := os.Stat(logPath); os.IsNotExist(err) {
 		if _, err := os.Create(logPath); err != nil {
-			return err
+			log15.Error("Failed to create log dir", logPath, err)
 		}
 	}
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
-		return err
+		log15.Error("Failed to open log file", logPath, err)
 	}
 	defer f.Close()
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{


### PR DESCRIPTION
# What did you implement:

OVAL fetch for Oracle had previously ignored Arch, which caused false positives in Vuls.

"CVE-2011-1079"

When I scan Oracle Linux7 on x86_64, the following are detected.

```
        "CVE-2011-1079": {
            "affectedPackages": [
                {
                    "name": "python-perf",
                    "notFixedYet": true,
                    "fixState": "Not fixed yet",
                    "fixedIn": "0:4.14.35-1902.2.0.el7uek"
                }
            ]
```

It is correct that this only detects aarch64, and should not be detected on x86_64.

```
<criterion test_ref="oval:com.oracle.elsa:tst:20194685001" comment="Oracle Linux 7 is installed"/>
<criteria operator="OR">
<criteria operator="AND">
<criterion test_ref="oval:com.oracle.elsa:tst:20194685002" comment="Oracle Linux arch is aarch64"/>
...
<criterion test_ref="oval:com.oracle.elsa:tst:20194685021" comment="python-perf is earlier than 0:4.14.35-1902.2.0.el7uek"/>
<criterion test_ref="oval:com.oracle.elsa:tst:20194685022" comment="python-perf is signed with the Oracle Linux 7 key"/>
```

In order to detect them correctly, Vuls need to know about the arch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
