### PR TITLE
fix(mysql): fix incorrect datetime value at fetch cmd

### DIFF
--- a/models/alpine.go
+++ b/models/alpine.go
@@ -51,8 +51,8 @@ func ConvertAlpineToModel(data *AlpineSecDB) (defs []Definition) {
 			DefinitionID: "def-" + cveID,
 			Advisory: Advisory{
 				Cves:    []Cve{{CveID: cveID}},
-				Issued:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
-				Updated: time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+				Issued:  time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				Updated: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 			},
 			References: []Reference{
 				{

--- a/models/alpine.go
+++ b/models/alpine.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"strings"
+	"time"
 )
 
 // AlpineSecDB is a struct of alpine secdb
@@ -49,7 +50,9 @@ func ConvertAlpineToModel(data *AlpineSecDB) (defs []Definition) {
 		def := Definition{
 			DefinitionID: "def-" + cveID,
 			Advisory: Advisory{
-				Cves: []Cve{{CveID: cveID}},
+				Cves:    []Cve{{CveID: cveID}},
+				Issued:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+				Updated: time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
 			},
 			References: []Reference{
 				{

--- a/models/amazon.go
+++ b/models/amazon.go
@@ -48,6 +48,7 @@ func ConvertAmazonToModel(data *fetcher.UpdateInfo) (defs []Definition) {
 			Advisory: Advisory{
 				Cves:     cves,
 				Severity: alas.Severity,
+				Issued:   time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
 				Updated:  updatedAt,
 			},
 			References: refs,

--- a/models/amazon.go
+++ b/models/amazon.go
@@ -48,7 +48,7 @@ func ConvertAmazonToModel(data *fetcher.UpdateInfo) (defs []Definition) {
 			Advisory: Advisory{
 				Cves:     cves,
 				Severity: alas.Severity,
-				Issued:   time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+				Issued:   time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 				Updated:  updatedAt,
 			},
 			References: refs,

--- a/models/debian.go
+++ b/models/debian.go
@@ -33,7 +33,7 @@ func ConvertDebianToModel(root *oval.Root) (defs []Definition) {
 
 			var t time.Time
 			if ovaldef.Debian.Date == "" {
-				t = time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC)
+				t = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
 			} else {
 				t, _ = time.Parse(timeformat, ovaldef.Debian.Date)
 			}

--- a/models/debian.go
+++ b/models/debian.go
@@ -30,7 +30,13 @@ func ConvertDebianToModel(root *oval.Root) (defs []Definition) {
 
 		for _, distPack := range collectDebianPacks(ovaldef.Criteria) {
 			const timeformat = "2006-01-02"
-			t, _ := time.Parse(timeformat, ovaldef.Debian.Date)
+
+			var t time.Time
+			if ovaldef.Debian.Date == "" {
+				t = time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC)
+			} else {
+				t, _ = time.Parse(timeformat, ovaldef.Debian.Date)
+			}
 
 			def := Definition{
 				DefinitionID: ovaldef.ID,

--- a/models/models.go
+++ b/models/models.go
@@ -28,8 +28,8 @@ type Definition struct {
 	RootID uint `json:"-" xml:"-"`
 
 	DefinitionID  string
-	Title         string
-	Description   string `gorm:"type:text"`
+	Title         string `gorm:"type:text"`
+	Description   string `gorm:"size:16777215"`
 	Advisory      Advisory
 	Debian        Debian
 	AffectedPacks []Package

--- a/models/models.go
+++ b/models/models.go
@@ -29,7 +29,7 @@ type Definition struct {
 
 	DefinitionID  string
 	Title         string
-	Description   string `sql:"type:text"`
+	Description   string `gorm:"type:text"`
 	Advisory      Advisory
 	Debian        Debian
 	AffectedPacks []Package

--- a/models/oracle.go
+++ b/models/oracle.go
@@ -2,10 +2,10 @@ package models
 
 import (
 	"strings"
+	"time"
 
 	"github.com/ymomoi/goval-parser/oval"
 
-	"github.com/kotakanbe/goval-dictionary/config"
 	c "github.com/kotakanbe/goval-dictionary/config"
 )
 
@@ -49,6 +49,8 @@ func ConvertOracleToModel(root *oval.Root) (roots []Root) {
 				Advisory: Advisory{
 					Cves:     copyCves,
 					Severity: ovaldef.Advisory.Severity,
+					Issued:   time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+					Updated:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
 				},
 				AffectedPacks: []Package{distPack.pack},
 				References:    copyRs,
@@ -66,7 +68,7 @@ func ConvertOracleToModel(root *oval.Root) (roots []Root) {
 				m[distPack.osVer] = root
 			} else {
 				m[distPack.osVer] = Root{
-					Family:      config.Oracle,
+					Family:      c.Oracle,
 					OSVersion:   distPack.osVer,
 					Definitions: []Definition{def},
 				}

--- a/models/oracle.go
+++ b/models/oracle.go
@@ -49,8 +49,8 @@ func ConvertOracleToModel(root *oval.Root) (roots []Root) {
 				Advisory: Advisory{
 					Cves:     copyCves,
 					Severity: ovaldef.Advisory.Severity,
-					Issued:   time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
-					Updated:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+					Issued:   time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					Updated:  time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 				},
 				AffectedPacks: []Package{distPack.pack},
 				References:    copyRs,

--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -3,6 +3,7 @@ package models
 import (
 	"regexp"
 	"strings"
+	"time"
 
 	c "github.com/kotakanbe/goval-dictionary/config"
 	"github.com/ymomoi/goval-parser/oval"
@@ -47,8 +48,13 @@ func ConvertUbuntuToModel(root *oval.Root) (defs []Definition) {
 			Description:  d.Description,
 			Advisory: Advisory{
 				Severity: d.Advisory.Severity,
+				Issued:   time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+				Updated:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
 			},
-			Debian:        Debian{CveID: cveID},
+			Debian: Debian{
+				CveID: cveID,
+				Date:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+			},
 			AffectedPacks: collectUbuntuPacks(d.Criteria),
 			References:    rs,
 		}

--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -48,12 +48,12 @@ func ConvertUbuntuToModel(root *oval.Root) (defs []Definition) {
 			Description:  d.Description,
 			Advisory: Advisory{
 				Severity: d.Advisory.Severity,
-				Issued:   time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
-				Updated:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+				Issued:   time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				Updated:  time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 			},
 			Debian: Debian{
 				CveID: cveID,
-				Date:  time.Date(1, time.January, 2, 0, 0, 0, 0, time.UTC),
+				Date:  time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 			},
 			AffectedPacks: collectUbuntuPacks(d.Criteria),
 			References:    rs,


### PR DESCRIPTION
# What did you implement:
Fixes #80 

Inserting 0000-00-00 into datetime is not a good idea in MySQL.
ref: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_date

So this PR solves this problem by filling the datetime with the lower limit of the range supported by MySQL. Also, the problem of overflow in Oracle has been resolved.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
// SQLite3
$ sqlite3 --version
3.31.1 2020-01-27 19:55:54 3bfa9cc97da10598521b342961df8f5f68c7388fa117345eeb516eaa837balt1

$ goval-dictionary fetch-debian 7 8 9 10
$ goval-dictionary fetch-ubuntu 14 16 18 19 20
$ goval-dictionary fetch-oracle
$ goval-dictionary fetch-amazon
$ goval-dictionary fetch-alpine 3.3 3.4 3.5 3.6

// MySQL
$ mysql --version
mysql  Ver 8.0.25-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))

$ goval-dictionary fetch-debian --dbtype=mysql --dbpath="mainek00n:password@tcp(localhost:3306)/oval?parseTime=true" 7 8 9 10
$ goval-dictionary fetch-ubuntu --dbtype=mysql --dbpath="mainek00n:password@tcp(localhost:3306)/oval?parseTime=true" 14 16 18 19 20
$ goval-dictionary fetch-oracle --dbtype=mysql --dbpath="mainek00n:password@tcp(localhost:3306)/oval?parseTime=true"
$ goval-dictionary fetch-amazon --dbtype=mysql --dbpath="mainek00n:password@tcp(localhost:3306)/oval?parseTime=true"
$ goval-dictionary fetch-alpine --dbtype=mysql --dbpath="mainek00n:password@tcp(localhost:3306)/oval?parseTime=true" 3.3 3.4 3.5 3.6

// postgreSQL
$ psql --version
psql (PostgreSQL) 12.7 (Ubuntu 12.7-0ubuntu0.20.04.1)

$ goval-dictionary fetch-debian --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval" 7 8 9 10
$ goval-dictionary fetch-ubuntu --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval" 14 16 18 19 20
$ goval-dictionary fetch-oracle --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval"
$ goval-dictionary fetch-amazon --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval"
$ goval-dictionary fetch-alpine --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval" 3.3 3.4 3.5 3.6
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

