### PR TITLE
fix(ubuntu): do not register anything with an unknown CVE ID

### DIFF
--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -28,6 +28,10 @@ func ConvertUbuntuToModel(root *oval.Root) (defs []Definition) {
 			}
 		}
 
+		if cveID == "" {
+			continue
+		}
+
 		for _, r := range d.Advisory.Refs {
 			rs = append(rs, Reference{
 				Source: "Ref",


### PR DESCRIPTION
# What did you implement:
The CVE ID may become "" in Ubuntu's ConvertUbuntuToModel, which is not affected in Redis due to the following location, but is still inserted in RDB.
https://github.com/kotakanbe/goval-dictionary/blob/b84c78b96673bf95945cd7daded7593a4b96c834/db/redis.go#L206-L208

This will cause a difference in the server mode response between Redis and RDB.
For example, in the Ubuntu 14 environment, the response to mysql-5.5 in RDB and Redis will look like the following file. The difference is the inclusion of the following OVAL definition.
[rdb_585b989.json.txt](https://github.com/kotakanbe/goval-dictionary/files/6635556/rdb_585b989.json.txt)
[redis_585b989.json.txt](https://github.com/kotakanbe/goval-dictionary/files/6635557/redis_585b989.json.txt)

```json
{
    "DefinitionID": "oval:com.ubuntu.trusty:def:201310000000",
    "Title": "CVE-2013-NNN1 on Ubuntu 14.04 LTS (trusty) - low.",
    "Description": "The mysql-5.5 package misses the patches applied previous in Debian's mysql-5.1 to drop the database \"test\" and the permissions that allow anonymous access, without a password, from localhost to the \"test\" database and any databases starting with \"test_\". This update reintroduces these patches for the mysql-5.5 package.",
    "Advisory": {
      "Severity": "Low",
      "Issued": "1000-01-01T00:00:00Z",
      "Updated": "1000-01-01T00:00:00Z"
    },
    "Debian": {
      "CveID": "",
      "MoreInfo": "",
      "Date": "1000-01-01T00:00:00Z"
    },
    "AffectedPacks": [
      {
        "Name": "mysql-5.5",
        "Version": "5.5.35+dfsg-1ubuntu1",
        "Arch": "",
        "NotFixedYet": false,
        "ModularityLabel": ""
      }
    ],
    "References": [
      {
        "Source": "Ref",
        "RefID": "",
        "RefURL": "http://people.canonical.com/~ubuntu-security/cve/2013/CVE-2013-NNN1.html"
      },
      {
        "Source": "Bug",
        "RefID": "",
        "RefURL": "https://launchpad.net/bugs/1261529"
      },
      {
        "Source": "Bug",
        "RefID": "",
        "RefURL": "http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=732306"
      }
    ]
  },
```

So, ignore the CVE ID of "" in ConvertUbuntuToModel.
The response will change to something like the following, without the definition of CVE-2013-NNN1.
[rdb_ee8cf3b.json.txt](https://github.com/kotakanbe/goval-dictionary/files/6635562/rdb_ee8cf3b.json.txt)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
# upstream/master
$ sqlite oval.b84c78b.sqlite3
sqlite> select * from debians where cve_id = "";
id|definition_id|cve_id|more_info|date
1|1|||1000-01-01 00:00:00+00:00
3057|3057|||1000-01-01 00:00:00+00:00
sqlite> select * from definitions where id in (1, 3057);
id|root_id|definition_id|title|description
1|1|oval:com.ubuntu.trusty:def:100|Check that Ubuntu 14.04 LTS (trusty) is installed.|
3057|1|oval:com.ubuntu.trusty:def:201310000000|CVE-2013-NNN1 on Ubuntu 14.04 LTS (trusty) - low.|The mysql-5.5 package misses the patches applied previous in Debian's mysql-5.1 to drop the database "test" and the permissions that allow anonymous access, without a password, from localhost to the "test" database and any databases starting with "test_". This update reintroduces these patches for the mysql-5.5 package.

$ curl http://127.0.0.1:1325/packs/ubuntu/14/mysql-5.5 | jq | grep "CVE-2013-NNN1"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  250k    0  250k    0     0  3797k      0 --:--:-- --:--:-- --:--:-- 3797k
    "Title": "CVE-2013-NNN1 on Ubuntu 14.04 LTS (trusty) - low.",
        "RefURL": "http://people.canonical.com/~ubuntu-security/cve/2013/CVE-2013-NNN1.html"

# PR
$ sqlite oval.ee8cf3b.sqlite3
sqlite> select * from debians where cve_id = "";
sqlite> 

$ curl http://127.0.0.1:1325/packs/ubuntu/14/mysql-5.5 | jq | grep "CVE-2013-NNN1"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  249k    0  249k    0     0  7796k      0 --:--:-- --:--:-- --:--:-- 7796k
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

