### PR TITLE
thread safety : prevent a race condition in the RDMS driver (sqlite, mysql, postgresql)

### DIFF
--- a/db/rdb/rdb.go
+++ b/db/rdb/rdb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"sync"
 
 	"github.com/jinzhu/gorm"
 	c "github.com/kotakanbe/goval-dictionary/config"
@@ -15,7 +16,6 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	"sync"
 )
 
 // Supported DB dialects.

--- a/db/rdb/rdb.go
+++ b/db/rdb/rdb.go
@@ -3,8 +3,8 @@ package rdb
 import (
 	"fmt"
 	"strings"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/jinzhu/gorm"
 	c "github.com/kotakanbe/goval-dictionary/config"
@@ -39,7 +39,7 @@ type OvalDB interface {
 	InsertOval(*models.Root, models.FetchMeta, *gorm.DB) error
 }
 
-var ovalMap map[string]OvalDB = map[string]OvalDB{}
+var ovalMap = map[string]OvalDB{}
 
 // NewRDB return RDB driver
 func NewRDB(family, dbType, dbpath string, debugSQL bool) (driver *Driver, locked bool, err error) {


### PR DESCRIPTION
# Description

Under a very low load of vuls scans (4 scans in parallel) a race condition occurs and makes the program crash

Stack trace :
```
fatal error: concurrent map writes

goroutine 70637 [running]:
runtime.throw(0xb58f0f, 0x15)
        /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc0008c7430 sp=0xc0008c7400 pc=0x43de92
runtime.mapassign_faststr(0xaae560, 0xc0005c2000, 0xb4f678, 0x6, 0x1)
        /usr/local/go/src/runtime/map_faststr.go:211 +0x3f1 fp=0xc0008c7498 sp=0xc0008c7430 pc=0x41c091
github.com/kotakanbe/goval-dictionary/db/rdb.(*Driver).NewOvalDB(0xc0008da000, 0xc0007f8132, 0x6, 0x3e, 0x94)
        /go/src/github.com/kotakanbe/goval-dictionary/db/rdb/rdb.go:76 +0x87c fp=0xc0008c7548 sp=0xc0008c7498 pc=0x888f9c
github.com/kotakanbe/goval-dictionary/db/rdb.NewRDB(0xc0007f8132, 0x6, 0xb5009a, 0x7, 0x7ffcb741670a, 0x11, 0x0, 0xcc3999, 0x3e, 0x94, ...)
        /go/src/github.com/kotakanbe/goval-dictionary/db/rdb/rdb.go:51 +0x199 fp=0xc0008c75a8 sp=0xc0008c7548 pc=0x888699
github.com/kotakanbe/goval-dictionary/db.NewDB(0xc0007f8132, 0x6, 0xb5009a, 0x7, 0x7ffcb741670a, 0x11, 0x0, 0x0, 0x0, 0x9688, ...)
        /go/src/github.com/kotakanbe/goval-dictionary/db/db.go:28 +0x9c fp=0xc0008c7620 sp=0xc0008c75a8 pc=0x8db71c
github.com/kotakanbe/goval-dictionary/server.getLastModified.func1(0xc18258, 0xc0002a48c0, 0x0, 0x0)
        /go/src/github.com/kotakanbe/goval-dictionary/server/server.go:149 +0x26e fp=0xc0008c7748 sp=0xc0008c7620 pc=0x966f6e
```

It is because concurrent writes to the global map ovalMap was allowed. It is then required to allow only one thread modify the map at the same time.

Another little improvement is possible too. This ovalMap should be defined only once : when it is declared in the package not every time the NewRDB function is called.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested during a benchmark : under a moderate load of 10 parallel scans against a vuls running in the server mode.

# Checklist:

- [ X] Check that there aren't other open pull requests for the same issue/feature

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

