### PR TITLE
feat(redis): add expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Available Commands:
   ubuntu      Fetch Vulnerability dictionary from Ubuntu
 
 Flags:
-      --expire uint   timeout to set for Redis keys
+      --expire uint   timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -h, --help          help for fetch
       --no-details    without vulnerability details
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Available Commands:
   ubuntu      Fetch Vulnerability dictionary from Ubuntu
 
 Flags:
-  -h, --help         help for fetch
-      --no-details   without vulnerability details
+      --expire uint   timeout to set for Redis keys
+  -h, --help          help for fetch
+      --no-details    without vulnerability details
 
 Global Flags:
       --config string       config file (default is $HOME/.oval.yaml)

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -18,6 +18,6 @@ func init() {
 	fetchCmd.PersistentFlags().Bool("no-details", false, "without vulnerability details")
 	_ = viper.BindPFlag("no-details", fetchCmd.PersistentFlags().Lookup("no-details"))
 
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
 	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -17,4 +17,7 @@ func init() {
 
 	fetchCmd.PersistentFlags().Bool("no-details", false, "without vulnerability details")
 	_ = viper.BindPFlag("no-details", fetchCmd.PersistentFlags().Lookup("no-details"))
+
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -215,7 +215,7 @@ func (d *RedisDriver) InsertOval(family string, root *models.Root, meta models.F
 					return fmt.Errorf("Failed to HSet Definition. err: %s", result.Err())
 				}
 				if expire > 0 {
-					if result := pipe.Expire(hashKey, time.Duration(expire*uint(time.Second))); result.Err() != nil {
+					if err := pipe.Expire(hashKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 						return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 					}
 				}
@@ -237,7 +237,7 @@ func (d *RedisDriver) InsertOval(family string, root *models.Root, meta models.F
 					}
 
 					if expire > 0 {
-						if result := pipe.Expire(zkey, time.Duration(expire*uint(time.Second))); result.Err() != nil {
+						if err := pipe.Expire(zkey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 							return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 						}
 					}


### PR DESCRIPTION
# What did you implement:
Unlike RDBs, Redis does not lose old data. For users who do not want to be affected by old data remaining, it is possible to set a timeout deadline for keys using the Redis EXPIRE command.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ goval-dictionary fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6379/0" --expire 30

$ redis-cli -p 6379
127.0.0.1:6379> TTL "OVAL#oracle::7::CVE-2018-19788"
(integer) 25
127.0.0.1:6379> HGETALL "OVAL#oracle::7::CVE-2018-19788"
1) "oval:com.oracle.elsa:def:20192046"
2) "{\"DefinitionID\":\"oval:com.oracle.elsa:def:20192046\",\"Title\":\"ELSA-2019-2046:  polkit security and bug fix update (MODERATE)\",\"Description\":\"[0.112-22.0.1]\\n- Increase timeout to avoid defunct processes [Orabug: 26930744]\\n\\n[0.112-22]\\n- pkttyagent: polkit-agent-helper-1 timeout leaves tty echo disabled\\n- Resolves: rhbz#1325512\\n\\n[0.112-21]\\n- Mitigation of regression caused by fix of CVE-2018-19788\\n- Resolves: rhbz#1656377\\n\\n[0.112-20]\\n- Fix of CVE-2019-6133, PID reuse via slow fork\\n- Resolves: rhbz#1667312\\n\\n[0.112-19]\\n- Fix of CVE-2018-19788, priv escalation with high UIDs\\n- Resolves: rhbz#1656377\",\"Advisory\":{\"Severity\":\"MODERATE\",\"Cves\":[{\"CveID\":\"CVE-2018-19788\",\"Cvss2\":\"\",\"Cvss3\":\"\",\"Cwe\":\"\",\"Impact\":\"\",\"Href\":\"https://linux.oracle.com/cve/CVE-2018-19788.html\",\"Public\":\"\"}],\"Bugzillas\":null,\"AffectedCPEList\":null,\"Issued\":\"1000-01-01T00:00:00Z\",\"Updated\":\"1000-01-01T00:00:00Z\"},\"Debian\":{\"CveID\":\"\",\"MoreInfo\":\"\",\"Date\":\"0001-01-01T00:00:00Z\"},\"AffectedPacks\":[{\"Name\":\"polkit\",\"Version\":\"0:0.112-22.0.1.el7\",\"Arch\":\"aarch64\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"},{\"Name\":\"polkit-devel\",\"Version\":\"0:0.112-22.0.1.el7\",\"Arch\":\"aarch64\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"},{\"Name\":\"polkit-docs\",\"Version\":\"0:0.112-22.0.1.el7\",\"Arch\":\"aarch64\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"},{\"Name\":\"polkit\",\"Version\":\"0:0.112-22.0.1.el7\",\"Arch\":\"x86_64\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"},{\"Name\":\"polkit-devel\",\"Version\":\"0:0.112-22.0.1.el7\",\"Arch\":\"x86_64\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"},{\"Name\":\"polkit-docs\",\"Version\":\"0:0.112-22.0.1.el7\",\"Arch\":\"x86_64\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"}],\"References\":[{\"Source\":\"elsa\",\"RefID\":\"ELSA-2019-2046\",\"RefURL\":\"https://linux.oracle.com/errata/ELSA-2019-2046.html\"},{\"Source\":\"CVE\",\"RefID\":\"CVE-2018-19788\",\"RefURL\":\"https://linux.oracle.com/cve/CVE-2018-19788.html\"}]}"
127.0.0.1:6379> TTL "OVAL#oracle::7::CVE-2018-19788"
(integer) -2
127.0.0.1:6379> HGETALL "OVAL#oracle::7::CVE-2018-19788"
(empty array)

127.0.0.1:6379> TTL "OVAL#redis::x86_64"
(integer) 12
127.0.0.1:6379> ZRange  "OVAL#redis::x86_64" 0 -1
1) "OVAL#oracle::8::CVE-2019-10192"
2) "OVAL#oracle::8::CVE-2019-10193"
3) "OVAL#oracle::8::CVE-2021-29477"
127.0.0.1:6379> TTL "OVAL#redis::x86_64"
(integer) -2
127.0.0.1:6379> ZRange  "OVAL#redis::x86_64" 0 -1
(empty array)

127.0.0.1:6379> keys *
(empty array)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://redis.io/commands/expire
