### PR TITLE
feat(GAdocker): Publish docker image with Github Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: vuls/goval-dictionary
+          tags: |
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            vuls/goval-dictionary:latest
+            ${{ steps.meta.outputs.tags }}
+          secrets: |
+            "github_token=${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# What did you implement:

Publish docker image "vuls/vuls" with Github Actions when Vuls is added tag or pushed at master branch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on my repository is forked. 

1. Push to my repository (branch:GAdocker)
2. Merge GAdocker branch
3. Run [Github Actions](https://github.com/tttfrfr2/goval-dictionary/actions/runs/1157697144) (can check how run Github Actions "Publish-docker-image")
4. Update docker image ([docker hub](https://hub.docker.com/layers/vuls/goval-dictionary/latest/images/sha256-6b7d55a5bf1ae7a98f387fc0ae1363855991f7ffce4d0caf1587f2fdf53d093b?context=repo)) (can check vuls:vuls was updated by tttfrfr2)

# Checklist:
You don't have to satisfy all of the following.

- [x] Enable "Allow edits from maintainers" for this PR

# Tips

Note that this Github Action "Publish-docker-image" is run correctly only if Secrets, "DOCKERHUB_USERNAME" and "DOCKERHUB_TOKEN", were setting.

***Is this ready for review?:*** Yes
