### PR TITLE
chore(integration-test): Output json files when diff under ./integration/diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ goval-dictionary
 *.sqlite3-wal
 tags
 /dist/
+integration/diff

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,6 +89,7 @@ clean-integration:
 	-pkill goval-dict.old
 	-pkill goval-dict.new
 	-rm integration/goval-dict.old integration/goval-dict.new integration/oval.old.sqlite3 integration/oval.new.sqlite3
+	-rm integration/diff/*
 	-docker kill redis-old redis-new
 	-docker rm redis-old redis-new
 

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 import os
 import random
 import math
-
+import json
 
 def diff_response(args: Tuple[str, str, str, str, str]):
     # Endpoint
@@ -51,7 +51,11 @@ def diff_response(args: Tuple[str, str, str, str, str]):
     if diff != {}:
         logger.warning(
             f'There is a difference between old and new(or RDB and Redis):\n {pprint.pformat({"mode": args[0], "args": args, "diff": diff}, indent=2)}')
-
+        filename = path.rsplit('/',1)[1]
+        with open(f'./integration/diff/{filename}.old', 'w') as w:
+            w.write(json.dumps(response_old, indent=4))
+        with open(f'./integration/diff/{filename}.new', 'w') as w:
+            w.write(json.dumps(response_new, indent=4))
 
 parser = argparse.ArgumentParser()
 parser.add_argument('mode', choices=['cveid', 'package'],


### PR DESCRIPTION
To make it easy to check with your favorite diff tool.
```
$ vimdiff ./integration/diff/CVE-2003-0689.*
```

When testing integration, delete `./integration/diff`, and then retest.
```
$ pkill -KILL goval-dict.old ; pkill -KILL goval-dict.new; ps aux | grep goval; rm integration/diff/*; make diff-server-rdb-redis
```
